### PR TITLE
Fixing unordered fieldnames

### DIFF
--- a/dataknead/loaders/util.py
+++ b/dataknead/loaders/util.py
@@ -3,12 +3,12 @@ from enum import Enum
 # This assumes a list with dicts, loop over all dicts, and get the unique
 # keys
 def get_fieldnames(data):
-    fieldnames = set()
+    fieldnames = list()
 
     for item in data:
-        [fieldnames.add(key) for key in item.keys()]
+        [fieldnames.append(key) for key in item.keys()]
 
-    return list(fieldnames)
+    return list(dict.fromkeys(fieldnames))
 
 class SnifferType(Enum):
     list_with_dicts = 1


### PR DESCRIPTION
Using list instead of set to keep the items ordered correctly. Set is an unordered collection.
Removing duplicates by casting the list to a dict and then to a list again.